### PR TITLE
document project selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Via npx:
 npx good-first-issue <project>
 ```
 
-> To select from available projects, use the project selector by running `npx good-first-issue`
+> If project is omitted (e.g. `npx good-first-issue`), a project selector will be presented, allowing you to select from the list of available projects.
 
 As a global module:
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Via npx:
 npx good-first-issue <project>
 ```
 
+> To select from available projects, use the project selector by running `npx good-first-issue`
+
 As a global module:
 ```
 npm i -g good-first-issue


### PR DESCRIPTION
added documentation in the README for being prompted to select a project, instead of giving a name, which is a nice feature to showcase.