### PR TITLE
Make search random across all pages

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -53,8 +53,9 @@ function search (q) {
  * @returns {Issue[]} - transformed data
  */
 function transform (data) {
-  const issues = data.items.reduce((acc, item) => {
-    if (item.assignee === null && item.locked !== true) {
+  const issues = data.items
+    .filter(item => item.assignee === null && item.locked !== true)
+    .reduce((acc, item) => {
       return acc.concat({
         title: item.title,
         pr: item.number,
@@ -66,9 +67,7 @@ function transform (data) {
         assignees: item.assignees,
         locked: item.locked
       })
-    }
-    return acc
-  }, [])
+    }, [])
 
   return issues
 }

--- a/lib/search.js
+++ b/lib/search.js
@@ -29,7 +29,7 @@ function search (q) {
         const lastPageAllowed = pageCount > MAX_PAGE_ALLOWED ? MAX_PAGE_ALLOWED : pageCount
         // page_number is 1-based index
         var randomPage =
-          Math.floor(Math.random() * Math.floor(lastPageAllowed - 1)) + 1
+          Math.floor(Math.random() * Math.floor(lastPageAllowed)) + 1
 
         return octokit.search
           .issues(getSearchParams({ q: q, page: randomPage }))

--- a/lib/search.js
+++ b/lib/search.js
@@ -8,26 +8,31 @@ const octokit = require('@octokit/rest')({
   }
 })
 
-// GitHub search parameters for the Node.js org
-var sort = 'updated'
-var order = 'desc'
-
+/// GitHub search parameters for the Node.js org
+const SORT = 'updated'
+const ORDER = 'desc'
 // default params for octokit
-var perPage = 30
-var page = 1 // page_number is 1-based index
+const PER_PAGE = 30
+const PAGE = 1 // page_number is 1-based index
+
+// API does not allow more than 1000 results -> tested via "feeling-lucky"
+// MAX_RESULTS_ALLOWED = 1000
+// MAX_PAGE_ALLOWED = Math.ceil(MAX_RESULTS_POSSIBLE / PER_PAGE)
+const MAX_PAGE_ALLOWED = 34
 
 function search (q) {
   return octokit.search
-    .issues({ q, sort, order, perPage, page })
+    .issues(getSearchParams(q, SORT, ORDER, PER_PAGE, PAGE))
     .then(({ data }) => {
       if (data.total_count > data.items.length) {
-        const pageCount = Math.ceil(data.total_count / perPage)
+        const pageCount = Math.ceil(data.total_count / PER_PAGE)
+        const lastPageAllowed = pageCount > MAX_PAGE_ALLOWED ? MAX_PAGE_ALLOWED : pageCount
         // page_number is 1-based index
-        const randomPage =
-          Math.floor(Math.random() * Math.floor(pageCount - 1)) + 1
+        var randomPage =
+          Math.floor(Math.random() * Math.floor(lastPageAllowed - 1)) + 1
 
         return octokit.search
-          .issues({ q, sort, order, perPage, randomPage })
+          .issues(getSearchParams(q, SORT, ORDER, PER_PAGE, randomPage))
           .then(({ data }) => {
             return transform(data)
           })
@@ -35,6 +40,16 @@ function search (q) {
         return transform(data)
       }
     })
+}
+
+function getSearchParams (q, sort, order, perPage, page) {
+  return {
+    q: q,
+    sort: sort || SORT,
+    order: order || ORDER,
+    per_page: perPage || PER_PAGE,
+    page: page || PAGE
+  }
 }
 
 /**

--- a/lib/search.js
+++ b/lib/search.js
@@ -22,7 +22,7 @@ const MAX_PAGE_ALLOWED = 34
 
 function search (q) {
   return octokit.search
-    .issues(getSearchParams(q, SORT, ORDER, PER_PAGE, PAGE))
+    .issues(getSearchParams({ q }))
     .then(({ data }) => {
       if (data.total_count > data.items.length) {
         const pageCount = Math.ceil(data.total_count / PER_PAGE)
@@ -32,7 +32,7 @@ function search (q) {
           Math.floor(Math.random() * Math.floor(lastPageAllowed - 1)) + 1
 
         return octokit.search
-          .issues(getSearchParams(q, SORT, ORDER, PER_PAGE, randomPage))
+          .issues(getSearchParams({ q: q, page: randomPage }))
           .then(({ data }) => {
             return transform(data)
           })
@@ -42,13 +42,13 @@ function search (q) {
     })
 }
 
-function getSearchParams (q, sort, order, perPage, page) {
+function getSearchParams (searchParams) {
   return {
-    q: q,
-    sort: sort || SORT,
-    order: order || ORDER,
-    per_page: perPage || PER_PAGE,
-    page: page || PAGE
+    q: searchParams['q'],
+    sort: searchParams['sort'] || SORT,
+    order: searchParams['order'] || ORDER,
+    per_page: searchParams['per_page'] || PER_PAGE,
+    page: searchParams['page'] || PAGE
   }
 }
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -12,25 +12,65 @@ const octokit = require('@octokit/rest')({
 var sort = 'updated'
 var order = 'desc'
 
+// default params for octokit
+var perPage = 30
+var page = 1 // page_number is 1-based index
+
 function search (q) {
-  return octokit.search.issues({ q, sort, order }).then(({ data }) => {
-    return data.items.reduce((acc, item) => {
-      if (item.assignee === null && item.locked !== true) {
-        return acc.concat({
-          title: item.title,
-          pr: item.number,
-          labels: item.labels,
-          state: item.state,
-          repo: item.repository_url,
-          url: item.html_url,
-          assignee: item.assignee,
-          assignees: item.assignees,
-          locked: item.locked
-        })
+  return octokit.search
+    .issues({ q, sort, order, perPage, page })
+    .then(({ data }) => {
+      if (data.total_count > data.items.length) {
+        const pageCount = Math.ceil(data.total_count / perPage)
+        // page_number is 1-based index
+        const randomPage =
+          Math.floor(Math.random() * Math.floor(pageCount - 1)) + 1
+
+        return octokit.search
+          .issues({ q, sort, order, perPage, randomPage })
+          .then(({ data }) => {
+            return transform(data)
+          })
+      } else {
+        return transform(data)
       }
-      return acc
-    }, [])
-  })
+    })
+}
+
+/**
+ * @typedef {Object} Issue
+ * @property {string} title
+ * @property {string} pr
+ * @property {Object[]} labels
+ * @property {string} repo
+ * @property {string} url
+ * @property {string} assignee - one assignee (it is due to backward compatibility)
+ * @property {Object[]} assignees - multiple assignee
+ * @property {boolean} locked
+ *
+ * Transform the data from Octokit Issue search to {@link Issue} format
+ * @param {*} data - data from Octokit Issue search
+ * @returns {Issue[]} - transformed data
+ */
+function transform (data) {
+  const issues = data.items.reduce((acc, item) => {
+    if (item.assignee === null && item.locked !== true) {
+      return acc.concat({
+        title: item.title,
+        pr: item.number,
+        labels: item.labels,
+        state: item.state,
+        repo: item.repository_url,
+        url: item.html_url,
+        assignee: item.assignee,
+        assignees: item.assignees,
+        locked: item.locked
+      })
+    }
+    return acc
+  }, [])
+
+  return issues
 }
 
 module.exports = search

--- a/lib/search.spec.js
+++ b/lib/search.spec.js
@@ -16,7 +16,8 @@ beforeEach(() => {
   search = require('./search')
 })
 
-test('should return filtered issues', () => {
+test('should return filtered issues if there is only one page', () => {
+
   const items = [
     {
       title: 'fooTitle',
@@ -53,8 +54,11 @@ test('should return filtered issues', () => {
     }
   ]
 
+  const total_count = items.length
+
   issues.mockResolvedValue({
     data: {
+      total_count,
       items
     }
   })
@@ -63,6 +67,112 @@ test('should return filtered issues', () => {
     expect(result).toEqual([
       {
         title: 'fooTitle',
+        pr: 123,
+        labels: 'fooLabels',
+        state: 'fooState',
+        repo: 'fooRepoUrl',
+        url: 'fooHtmlUrl',
+        assignee: null,
+        assignees: 'fooAssignees',
+        locked: false
+      }
+    ])
+  )
+})
+
+test('should return filtered issues if there is more than one page', () => {
+
+  const firstCallItems = [
+    {
+      title: 'fooFirstTitle',
+      number: 123,
+      labels: 'fooLabels',
+      state: 'fooState',
+      repository_url: 'fooRepoUrl',
+      html_url: 'fooHtmlUrl',
+      assignee: null,
+      assignees: 'fooAssignees',
+      locked: false
+    },
+    {
+      title: 'barFirstTitle',
+      number: 123,
+      labels: 'barLabels',
+      state: 'barState',
+      repository_url: 'barRepoUrl',
+      html_url: 'barHtmlUrl',
+      assignee: 'barAssignee',
+      assignees: 'barAssignees',
+      locked: false
+    },
+    {
+      title: 'bazFirstTitle',
+      number: 123,
+      labels: 'bazLabels',
+      state: 'bazState',
+      repository_url: 'bazRepoUrl',
+      html_url: 'bazHtmlUrl',
+      assignee: null,
+      assignees: 'bazAssignees',
+      locked: true
+    }
+  ]
+
+  const secondCallItems = [
+    {
+      title: 'fooSecondTitle',
+      number: 123,
+      labels: 'fooLabels',
+      state: 'fooState',
+      repository_url: 'fooRepoUrl',
+      html_url: 'fooHtmlUrl',
+      assignee: null,
+      assignees: 'fooAssignees',
+      locked: false
+    },
+    {
+      title: 'barSecondTitle',
+      number: 123,
+      labels: 'barLabels',
+      state: 'barState',
+      repository_url: 'barRepoUrl',
+      html_url: 'barHtmlUrl',
+      assignee: 'barAssignee',
+      assignees: 'barAssignees',
+      locked: false
+    },
+    {
+      title: 'bazSecondTitle',
+      number: 123,
+      labels: 'bazLabels',
+      state: 'bazState',
+      repository_url: 'bazRepoUrl',
+      html_url: 'bazHtmlUrl',
+      assignee: null,
+      assignees: 'bazAssignees',
+      locked: true
+    }
+  ]
+
+  //set total_count more than default per_page = 30
+  const total_count = 45;
+
+  issues.mockResolvedValueOnce({
+    data: {
+      total_count,
+      items: firstCallItems
+    }
+  }).mockResolvedValueOnce({
+    data: {
+      total_count,
+      items: secondCallItems
+    }
+  })
+
+  return search({}).then(result =>
+    expect(result).toEqual([
+      {
+        title: 'fooSecondTitle',
         pr: 123,
         labels: 'fooLabels',
         state: 'fooState',

--- a/lib/search.spec.js
+++ b/lib/search.spec.js
@@ -63,7 +63,8 @@ test('should return filtered issues if there is only one page', () => {
     }
   })
 
-  return search({}).then(result =>
+  return search({}).then(result => {
+    expect(issues).toHaveBeenCalledTimes(1)
     expect(result).toEqual([
       {
         title: 'fooTitle',
@@ -77,7 +78,8 @@ test('should return filtered issues if there is only one page', () => {
         locked: false
       }
     ])
-  )
+    
+    })
 })
 
 test('should return filtered issues if there is more than one page', () => {
@@ -169,7 +171,10 @@ test('should return filtered issues if there is more than one page', () => {
     }
   })
 
-  return search({}).then(result =>
+  return search({}).then(result => {
+    expect(issues).toHaveBeenCalledTimes(2)    
+    const searchParams = issues.mock.calls[1][0]
+    expect(searchParams["page"]).toBeLessThanOrEqual(2)
     expect(result).toEqual([
       {
         title: 'fooSecondTitle',
@@ -183,7 +188,117 @@ test('should return filtered issues if there is more than one page', () => {
         locked: false
       }
     ])
-  )
+    
+  })
+})
+
+test('should return filtered issues if there are more than allowed pages', () => {
+
+  const firstCallItems = [
+    {
+      title: 'fooFirstTitle',
+      number: 123,
+      labels: 'fooLabels',
+      state: 'fooState',
+      repository_url: 'fooRepoUrl',
+      html_url: 'fooHtmlUrl',
+      assignee: null,
+      assignees: 'fooAssignees',
+      locked: false
+    },
+    {
+      title: 'barFirstTitle',
+      number: 123,
+      labels: 'barLabels',
+      state: 'barState',
+      repository_url: 'barRepoUrl',
+      html_url: 'barHtmlUrl',
+      assignee: 'barAssignee',
+      assignees: 'barAssignees',
+      locked: false
+    },
+    {
+      title: 'bazFirstTitle',
+      number: 123,
+      labels: 'bazLabels',
+      state: 'bazState',
+      repository_url: 'bazRepoUrl',
+      html_url: 'bazHtmlUrl',
+      assignee: null,
+      assignees: 'bazAssignees',
+      locked: true
+    }
+  ]
+
+  const secondCallItems = [
+    {
+      title: 'fooSecondTitle',
+      number: 123,
+      labels: 'fooLabels',
+      state: 'fooState',
+      repository_url: 'fooRepoUrl',
+      html_url: 'fooHtmlUrl',
+      assignee: null,
+      assignees: 'fooAssignees',
+      locked: false
+    },
+    {
+      title: 'barSecondTitle',
+      number: 123,
+      labels: 'barLabels',
+      state: 'barState',
+      repository_url: 'barRepoUrl',
+      html_url: 'barHtmlUrl',
+      assignee: 'barAssignee',
+      assignees: 'barAssignees',
+      locked: false
+    },
+    {
+      title: 'bazSecondTitle',
+      number: 123,
+      labels: 'bazLabels',
+      state: 'bazState',
+      repository_url: 'bazRepoUrl',
+      html_url: 'bazHtmlUrl',
+      assignee: null,
+      assignees: 'bazAssignees',
+      locked: true
+    }
+  ]
+
+  //set total_count more than allowed_records = 1000 
+  const total_count = 57000;
+
+  issues.mockResolvedValueOnce({
+    data: {
+      total_count,
+      items: firstCallItems
+    }
+  }).mockResolvedValueOnce({
+    data: {
+      total_count,
+      items: secondCallItems
+    }
+  })
+
+  return search({}).then(result =>{
+    expect(issues).toHaveBeenCalledTimes(2)    
+    const searchParams = issues.mock.calls[1][0]
+    expect(searchParams["page"]).toBeLessThanOrEqual(34)
+    expect(result).toEqual([
+      {
+        title: 'fooSecondTitle',
+        pr: 123,
+        labels: 'fooLabels',
+        state: 'fooState',
+        repo: 'fooRepoUrl',
+        url: 'fooHtmlUrl',
+        assignee: null,
+        assignees: 'fooAssignees',
+        locked: false
+      }
+    ])
+  })
 })
 
 test('should throw', async () => {


### PR DESCRIPTION
This PR addresses the concerns shown here: https://github.com/bnb/good-first-issue/issues/51#issuecomment-441110549 

### How it is done?
I see there is a field called total_count in the response. We can utilize that to figure out the number of pages as default is 30 items per page. So the idea is:

1. figure out the number of pages
2. select random page
3. select random issue from that page

## Note:

- [x] We will be making 2 calls to octokit apis for this. I'm not sure how it will affect rate-limiting.
- [x] changes to tests in `search.spec.js`.