### PR TITLE
docs: add markdown-magic to automatically add project

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you'd like to help with any of these, feel free to submit a PR or ask how you
 The table of projects which are _currently_ supported.
 
 <!--
-  This comment is automatically updated with `npm run markdown`
+  Content below is automatically updated with `npm run markdown`
   Please do not manually update these contents
 -->
 <!-- AUTO-GENERATED-CONTENT:START (PROJECTS:path=./data/projects.json) -->

--- a/README.md
+++ b/README.md
@@ -55,16 +55,20 @@ If you'd like to help with any of these, feel free to submit a PR or ask how you
 
 The table of projects which are _currently_ supported.
 
+<!--
+  This comment is automatically updated with `npm run markdown`
+  Please do not manually update these contents
+-->
 <!-- AUTO-GENERATED-CONTENT:START (PROJECTS:path=./data/projects.json) -->
 | S. No. | Name | Project `<project>` |
 | --- | --- | --- |
 |1.|Node.js|`node`|
 |2.|Electron|`electron`|
 |3.|VS Code|`vscode`|
-|4.|gutenberg|`gutenberg`|
+|4.|Gutenberg|`gutenberg`|
 |5.|wolkenkit|`wolkenkit`|
 |6.|TypeScript|`typescript`|
-|7.|strapi|`strapi`|
+|7.|Strapi|`strapi`|
 |8.|Create React App|`create-react-app`|
 |9.|debugger.html|`debugger.html`|
 |10.|webpack CLI|`webpack-cli`|

--- a/README.md
+++ b/README.md
@@ -55,17 +55,23 @@ If you'd like to help with any of these, feel free to submit a PR or ask how you
 
 The table of projects which are _currently_ supported.
 
+<!-- AUTO-GENERATED-CONTENT:START (PROJECTS:path=./data/projects.json) -->
 | S. No. | Name | Project `<project>` |
 | --- | --- | --- |
-| 1. | Node.js | `node` |
-| 2. | Electron | `electron` |
-| 3. | VS Code | `vscode` |
-| 4. | Gutenberg | `gutenberg` |
-| 5. | wolkenkit | `wolkenkit` |
-| 6. | TypeScript | `typescript` |
-| 7. | Strapi | `strapi` |
-| 8. | Create React App | `create-react-app` |
-| 9. | I'm Feeling Lucky (Random Project) | `feeling-lucky` |
+|1.|Node.js|`node`|
+|2.|Electron|`electron`|
+|3.|VS Code|`vscode`|
+|4.|gutenberg|`gutenberg`|
+|5.|wolkenkit|`wolkenkit`|
+|6.|TypeScript|`typescript`|
+|7.|strapi|`strapi`|
+|8.|Create React App|`create-react-app`|
+|9.|debugger.html|`debugger.html`|
+|10.|webpack CLI|`webpack-cli`|
+|11.|Jest|`jest`|
+|12.|I'm Feeling Lucky (Random Project)|`feeling-lucky`|
+|13.|Netlify|`netlify`|
+<!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Adding New Projects
 
@@ -74,8 +80,8 @@ If you'd like to add a new project to `good-first-issue`, you're more than welco
 - Update `data/projects.json`
   - Add your `<project>` as a property of `projects` with an object that includes a `name`, `description`, and a `q` (representing the GitHub search query).
 
-- Update `README.md`
-  - Add your `<project>` at the bottom of the [Projects](#projects) table above with `name` and `project`
+- Update `README.md` by running `npm run markdown`
+  - This will automatically update README.md with the new project
 
 ### Adding New Projects: More Information
 

--- a/data/projects.json
+++ b/data/projects.json
@@ -12,7 +12,7 @@
     "q": "repo:microsoft/vscode state:open label:\"good first issue\""
   },
   "gutenberg": {
-    "name": "gutenberg",
+    "name": "Gutenberg",
     "q": " repo:WordPress/gutenberg is:issue is:open sort:updated-desc label:\"good first issue\""
   },
   "wolkenkit": {
@@ -24,7 +24,7 @@
     "q": "repo:microsoft/typescript is:issue is:open label:\"good first issue\""
   },
   "strapi": {
-    "name": "strapi",
+    "name": "Strapi",
     "q": "repo:strapi/strapi is:issue is:open label:\"Good for new contributors\""
   },
   "create-react-app": {

--- a/markdown.config.js
+++ b/markdown.config.js
@@ -1,0 +1,31 @@
+const path = require('path')
+
+const HEADER = `
+| S. No. | Name | Project \`<project>\` |
+| --- | --- | --- |
+`.trim()
+
+module.exports = {
+  transforms: {
+    PROJECTS(content, options) {
+      const { path: filePath } = options
+      const projects = require(path.resolve(filePath))
+      const list = Object.keys(projects)
+        .map((name, index) => {
+          const project = projects[name]
+          return [
+            '',
+            `${index + 1}.`,
+            project.name,
+            `\`${name}\``,
+            ''
+          ].join('|')
+        })
+
+      return [
+        HEADER,
+        list.join('\n')
+      ].join('\n')
+    }
+  }
+}

--- a/markdown.config.js
+++ b/markdown.config.js
@@ -1,6 +1,6 @@
 const path = require('path')
 
-const HEADER = `
+const TABLE_HEADER = `
 | S. No. | Name | Project \`<project>\` |
 | --- | --- | --- |
 `.trim()
@@ -23,7 +23,7 @@ module.exports = {
         })
 
       return [
-        HEADER,
+        TABLE_HEADER,
         list.join('\n')
       ].join('\n')
     }

--- a/markdown.config.js
+++ b/markdown.config.js
@@ -7,7 +7,7 @@ const HEADER = `
 
 module.exports = {
   transforms: {
-    PROJECTS(content, options) {
+    PROJECTS (content, options) {
       const { path: filePath } = options
       const projects = require(path.resolve(filePath))
       const list = Object.keys(projects)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A CLI for finding good-first-issues in open source projects.",
   "main": "index.js",
   "scripts": {
+    "markdown": "md-magic",
     "pretest": "standard",
     "test": "jest --collectCoverage",
     "prepublish": "npm run test"
@@ -56,6 +57,7 @@
   },
   "devDependencies": {
     "jest": "^23.6.0",
+    "markdown-magic": "^0.1.25",
     "standard": "^12.0.1"
   }
 }


### PR DESCRIPTION
Fixes #52

This (small) PR adds markdown-magic which will automatically add projects to README.md when the `markdown` script is run. I've also updated the instructions on adding a project to use this script.