### PR TITLE
test: add markdown test for projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The table of projects which are _currently_ supported.
 |11.|Jest|`jest`|
 |12.|I'm Feeling Lucky (Random Project)|`feeling-lucky`|
 |13.|Netlify|`netlify`|
-|14.|bigtestjs.io|`bigtestjs.io`|
+|14.|BigTestjs.io|`bigtestjs.io`|
 |15.|Gatsby|`gatsby`|
 <!-- AUTO-GENERATED-CONTENT:END -->
 

--- a/markdown.config.spec.js
+++ b/markdown.config.spec.js
@@ -1,0 +1,58 @@
+const fs = require('fs')
+const README_PATH = "./README.md"
+const DATA_FILE_PATH = "./data/projects.json"
+
+test('should match README with data/project.json', () => {
+    const projectsFromReadme = getProjectsFromReadme()
+    const projectsFromDatafile = getProjectsFromDatafile()
+
+    expect(projectsFromReadme).toEqual(projectsFromDatafile)
+})
+
+// below function is influenced by all-contributers-cli, Thanks to @jfmengels and @kentcdodds
+// https://github.com/jfmengels/all-contributors-cli/blob/master/src/generate/index.js
+function getProjectsFromReadme() {
+
+    const fileContent = fs.readFileSync(README_PATH, "UTF-8")
+
+    const tagToLookFor = '<!-- AUTO-GENERATED-CONTENT:'
+    const closingTag = '-->'
+    const startOfOpeningTagIndex = fileContent.indexOf(
+        `${tagToLookFor}START`,
+    )
+    const endOfOpeningTagIndex = fileContent.indexOf(
+        closingTag,
+        startOfOpeningTagIndex,
+    )
+    const startOfClosingTagIndex = fileContent.indexOf(
+        `${tagToLookFor}END`,
+        endOfOpeningTagIndex,
+    )
+
+    const table = fileContent.slice(endOfOpeningTagIndex + closingTag.length,
+        startOfClosingTagIndex)
+
+    const regex = /\d+\.\|(.*)\|`(.*)`\|/gm;
+    var match = regex.exec(table)
+
+    var projects = {};
+    while (match != null) {
+        let project = match[2]
+        let name = match[1]
+        projects[project] = { "name": name }
+
+        match = regex.exec(table)
+    }
+
+    return projects
+}
+
+function getProjectsFromDatafile() {
+
+    let projects = require(DATA_FILE_PATH)
+    for (project in projects) {
+        delete projects[project]["q"]
+    }
+
+    return projects
+}


### PR DESCRIPTION
This PR addresses the issue #63 **(Add CI check for npm run markdown)**

This PR contains:
1. Test to verify if `README.md` has the same projects as `projects.json` 
2. change README:  **from** `bigtestjs.io` **to** `BigTestjs.io` (this typo/bug was found during testing)