### PR TITLE
[fix]: remove fs and path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,6 @@
-const fs = require('fs')
-const path = require('path')
 const search = require('./lib/search')
 
-const dataSrc = path.resolve(__dirname, 'data', 'projects.json')
-
-const projects = JSON.parse(fs.readFileSync(dataSrc))
+const projects = require('./data/projects.json')
 
 module.exports = async function (project) {
   return search(projects[project].q)


### PR DESCRIPTION
when used with configuring fs/path as `empty` mocking, it fails