### PR TITLE
Allow any org/repo combination

### DIFF
--- a/bin/good-first-issue.js
+++ b/bin/good-first-issue.js
@@ -26,22 +26,6 @@ cli
       input = await prompt()
     }
 
-    // if project is not found
-    if (!(input in projects)) {
-      console.log('')
-      console.log(chalk.red(`"${input}" was not found in good-first-issue.`))
-      console.log('--------------------------------')
-      console.log("If you'd like to add a new project to good-first-issue,")
-      console.log(
-        "Please see the module's Github repository: " +
-          chalk.cyan(
-            'https://github.com/bnb/good-first-issue#adding-new-projects'
-          )
-      )
-      console.log('')
-      process.exit(0)
-    }
-
     const issues = await goodFirstIssue(input)
 
     if (issues.length === 0) {

--- a/bin/good-first-issue.js
+++ b/bin/good-first-issue.js
@@ -36,7 +36,7 @@ cli
     }
 
     // Call the log functionality, output the result to the console.
-    let output = await log(issues, projects[input].name)
+    let output = await log(issues, (input in projects) ? projects[input].name : project)
 
     let key = cmd.first ? 0 : Math.floor(Math.random() * Math.floor(output.length - 1))
 

--- a/index.js
+++ b/index.js
@@ -3,5 +3,9 @@ const search = require('./lib/search')
 const projects = require('./data/projects.json')
 
 module.exports = async function (project) {
-  return search(projects[project].q)
+  if (project in projects) {
+    return search(projects[project].q)
+  } else {
+    return search(`${project.includes('/') ? 'repo' : 'org'}:${project} state:open label:"good first issue"`)
+  }
 }


### PR DESCRIPTION
👋 This PR allows for any repository or org to be passed, while still allowing special treatment for specific repositories/orgs.

So this will work as normal:

```
npx good-first-issue babel
```

But now you can do this to search the [ `atom/atom` repository](https://github.com/atom/atom):

```
npx good-first-issue atom/atom
```

Or this to search the [`github` organization](https://github.com)!

```
npx good-first-issue github
```

I haven't yet taken a look at writing tests for this - I totally can (and plan to) but since the majority of the changes are in the CLI script they're a little more challenging. Anyway - let me know what you think and if I need to make any more changes 🎉 

Closes #62 