### PR TITLE
More tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "devDependencies": {
     "jest": "^23.6.0",
     "markdown-magic": "^0.1.25",
+    "nock": "^10.0.4",
     "standard": "^12.0.1"
   }
 }

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -1,0 +1,38 @@
+const goodFirstIssue = require('..')
+const nock = require('nock')
+
+describe('goodFirstIssue', () => {
+  let items
+  beforeEach(() => {
+    items = [{
+      title: 'fooTitle',
+      number: 123,
+      labels: 'fooLabels',
+      state: 'fooState',
+      repository_url: 'fooRepoUrl',
+      html_url: 'fooHtmlUrl',
+      assignee: null,
+      assignees: 'fooAssignees',
+      locked: false
+    }]
+
+    // "Mock" network requests to the Search API
+    nock('https://api.github.com')
+      .get(/^\/search\/issues\?/).reply(200, { items })
+  })
+
+  it('returns the expected issues', async () => {
+    const actual = await goodFirstIssue('node')
+    expect(actual).toEqual([{
+      assignee: null,
+      assignees: 'fooAssignees',
+      labels: 'fooLabels',
+      locked: false,
+      pr: 123,
+      repo: 'fooRepoUrl',
+      state: 'fooState',
+      title: 'fooTitle',
+      url: 'fooHtmlUrl',
+    }])
+  })
+})

--- a/tests/markdown.config.spec.js
+++ b/tests/markdown.config.spec.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
-const README_PATH = "./README.md"
-const DATA_FILE_PATH = "./data/projects.json"
+const path = require('path')
+const README_PATH = path.join(__dirname, '..', 'README.md')
+const DATA_FILE_PATH = path.join(__dirname, '..', 'data', 'projects.json')
 
 test('should match README with data/project.json', () => {
     const projectsFromReadme = getProjectsFromReadme()
@@ -12,7 +13,6 @@ test('should match README with data/project.json', () => {
 // below function is influenced by all-contributers-cli, Thanks to @jfmengels and @kentcdodds
 // https://github.com/jfmengels/all-contributors-cli/blob/master/src/generate/index.js
 function getProjectsFromReadme() {
-
     const fileContent = fs.readFileSync(README_PATH, "UTF-8")
 
     const tagToLookFor = '<!-- AUTO-GENERATED-CONTENT:'
@@ -48,7 +48,6 @@ function getProjectsFromReadme() {
 }
 
 function getProjectsFromDatafile() {
-
     let projects = require(DATA_FILE_PATH)
     for (project in projects) {
         delete projects[project]["q"]

--- a/tests/search.spec.js
+++ b/tests/search.spec.js
@@ -13,11 +13,10 @@ beforeEach(() => {
       }
     }
   })
-  search = require('./search')
+  search = require('../lib/search')
 })
 
 test('should return filtered issues if there is only one page', () => {
-
   const items = [
     {
       title: 'fooTitle',
@@ -77,13 +76,11 @@ test('should return filtered issues if there is only one page', () => {
         assignees: 'fooAssignees',
         locked: false
       }
-    ])
-    
-    })
+    ])  
+  })
 })
 
 test('should return filtered issues if there is more than one page', () => {
-
   const firstCallItems = [
     {
       title: 'fooFirstTitle',
@@ -193,7 +190,6 @@ test('should return filtered issues if there is more than one page', () => {
 })
 
 test('should return filtered issues if there are more than allowed pages', () => {
-
   const firstCallItems = [
     {
       title: 'fooFirstTitle',


### PR DESCRIPTION
👋 This PR adds a test for the `index.js` `goodFirstIssue` file, and makes an attempt at organizing the test files a little differently. I poked around in #1 but didn't see any proposed implementation details, so I just went ahead and put things into a `/tests/` folder, which is what I normally do in my own projects.

I've added [`nock`](https://github.com/node-nock/nock), a wonderful library for mocking network requests. It allows us to not mock the Octokit library, but instead let Octokit do its thing as normal but be given our own fixture data instead of actually reaching out to the GitHub API. This way, we're replacing less code in our tests, and making them more reliable.

If possible, this should be merged before #89 so that I can add some tests into the `index.spec.js` file, and verify that the appropriate query params are being sent to the Search API.

I also fixed some formatting/whitespace/consistency things 😊 There's more tweaks I want to do (like `var => const`, wrapping test suites in `describe()`s) but I don't want this PR to get too difficult to review.